### PR TITLE
Replace all implementations with a single asynchronous `puresnmp` implementation

### DIFF
--- a/cyberpower_pdu/__init__.py
+++ b/cyberpower_pdu/__init__.py
@@ -10,6 +10,7 @@ from typing import override
 from puresnmp import V2C, Client, PyWrapper  # type: ignore[import-not-found]
 from puresnmp.types import Integer  # type: ignore[import-not-found]
 
+
 ############################################################
 #### Data types ############################################
 ############################################################

--- a/cyberpower_pdu/gui.py
+++ b/cyberpower_pdu/gui.py
@@ -34,6 +34,7 @@ from cyberpower_pdu import CyberPowerPDU, OutletCommand
 from cyberpower_pdu.widgets.ip_address_line_edit import IPAddressLineEdit
 from cyberpower_pdu.widgets.led_indicator import LedIndicator
 
+
 SIMULATE_HARDWARE = True
 
 

--- a/cyberpower_pdu/scripts/get_all_outlet_states.py
+++ b/cyberpower_pdu/scripts/get_all_outlet_states.py
@@ -4,6 +4,7 @@ import asyncio
 # Project dependencies
 from cyberpower_pdu import CyberPowerPDU
 
+
 IP_ADDRESS = "192.168.1.132"
 
 

--- a/cyberpower_pdu/scripts/get_outlet_state.py
+++ b/cyberpower_pdu/scripts/get_outlet_state.py
@@ -4,6 +4,7 @@ import asyncio
 # Project dependencies
 from cyberpower_pdu import CyberPowerPDU
 
+
 IP_ADDRESS = "192.168.1.132"
 OUTLET = 7
 

--- a/cyberpower_pdu/scripts/get_outlet_states.py
+++ b/cyberpower_pdu/scripts/get_outlet_states.py
@@ -5,6 +5,7 @@ import time
 # Project dependencies
 from cyberpower_pdu import CyberPowerPDU
 
+
 IP_ADDRESS = "192.168.1.132"
 
 

--- a/cyberpower_pdu/scripts/set_outlet_state.py
+++ b/cyberpower_pdu/scripts/set_outlet_state.py
@@ -5,6 +5,7 @@ import time
 # Project dependencies
 from cyberpower_pdu import CyberPowerPDU, OutletCommand
 
+
 # Script settings
 IP_ADDRESS = "192.168.1.132"
 OUTLET = 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ import_heading_firstparty = "Project dependencies"
 import_heading_localfolder = "Local dependencies"
 force_sort_within_sections = true
 combine_as_imports = true
+lines_after_imports = 2
 
 [tool.mypy]
 exclude = [".*/?\\.venv/.*", "/site-packages/"]


### PR DESCRIPTION
This library has been internally used for some time, where this PR's initial commits copied over that internal code to this branch. However, the `psynmp` (via `pysnmp-lextudio`), which was the library previously used, reliability has been a cause of several issues. It is very slow, where it takes around 1.2 seconds to get the status of just 16 outlets, and its asynchronous API can block the `asyncio` event loop for around 100ms at a time.

This PR replaces the implementation by using the `puresnmp` library which is fast, has a clean, modern Python API, and has a proper `asyncio`-compatible API. It also removes the synchronous implementations and also the Telnet implementation that were existing in the internal codebase. The GUI is currently non-functional due to the transition, and that will be updated in a later PR.