### PR TITLE
Fix simulation initialization

### DIFF
--- a/cyberpower_pdu/__init__.py
+++ b/cyberpower_pdu/__init__.py
@@ -111,9 +111,7 @@ class CyberPowerPDUSimulation(CyberPowerPDU):
     @override
     async def initialize(self) -> None:
         self.__number_of_outlets = 16
-
-        for index in range(self.__number_of_outlets):
-            self.__outlet_states[index] = False
+        self.__outlet_states = [False] * self.__number_of_outlets
 
     @override
     async def close(self) -> None:


### PR DESCRIPTION
This fixes a small bug in the initialization of simulation clients.

Background: I found this while working with the LLAMAS control server, where previously simulation Cyberpower PDUs weren't being initialized at all. Doing the initialization raised an exception, which led me here.