### PR TITLE
Make GUI dependencies optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,6 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.10, <3.13"
-telnetlib3 = "^2.0.4"
-pyside6 = "^6.7.2"
 puresnmp = "^2.0.1"
 
 [tool.poetry.group.dev.dependencies]
@@ -19,6 +17,9 @@ ruff = "^0.6.5"
 isort = "^5.13.2"
 mypy = "^1.11.2"
 poethepoet = "^0.28.0"
+
+[tool.poetry.group.gui.dependencies]
+pyside6 = "^6.7.2"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Currently, PySide6 is a required dependency to install this package, which is not needed for the main `CyberPowerPDU` client. This adds an optional `"gui"` dependency group with the PySide6 dependency, and also implements some logging improvements.